### PR TITLE
Clarify initial state when creating reconciler

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@
 - [Installation](#installation)
 - [Usage](#usage)
 - [How it works](#how-it-works)
-  - [Model state with the Reconciler](#model-state-with-the-reconciler)
-  - [Dispatch event with the Dispatcher](#dispatch-event-with-the-dispatcher)
+  - [Model state with Reconciler](#model-state-with-the-reconciler)
+  - [Dispatch event with Dispatcher](#dispatch-event-with-the-dispatcher)
   - [Handle events with Controllers](#handle-events-with-controllers)
   - [Query state reactively with Subscriptions](#query-state-reactively-with-subscriptions)
+- [Best practices](#best-practices)
 - [Roadmap](#roadmap)
 - [License](#license)
 
@@ -29,7 +30,7 @@ Have a simple, [re-frame](https://github.com/Day8/re-frame) like state managemen
 
 ## Installation
 
-Add to project.clj/build.boot: `[org.roman01la/scrum "1.0.0-SNAPSHOT"]`
+Add to *project.clj / build.boot*: `[org.roman01la/scrum "2.0.0-SNAPSHOT"]`
 
 ## Usage
 
@@ -106,7 +107,7 @@ With _Scrum_ you build everything around a well known architecture pattern in mo
 
 *RENDER* (automatic ! profit :+1:)
 
-### Model state with the Reconciler
+### Model state with Reconciler
 
 Reconciler is the core of _Scrum_. An instance of `Reconciler` takes care of application state, handles actions and subscriptions, and performs batched updates (via `requestAnimationFrame`):
 
@@ -116,15 +117,17 @@ Reconciler is the core of _Scrum_. An instance of `Reconciler` takes care of app
                      :controllers {:counter control}}))
 ```
 
-The value at the `:state` key is the initial state. You can pass either an atom of empty map that will be populated with the `:init` event or an atom with a map containing the whole initial state, modeled at your convenience.
+The value at the `:state` key is the initial state of the reconciler represented as an atom which holds a hash map.
 
-The value at the `:controllers` key is a map from key to controller function. The controller stores its state as a value of its key from this map. So the keys in the `:controllers` will be reflected in the `:state` atom. This is where modeling state happens and application domains keep separated.
+The value at the `:controllers` key is a hash map from controller name to controller function. The controller stores its state in reconciler's state atom at the key which is the name of the controller in `:controllers` hash map. That is the keys in the `:controllers` will be reflected in the `:state` atom. This is where modeling state happens and application domains keep separated.
 
-*NOTE*: the `:init` event pattern isn't enforced at all by scrum, but we consider it a good idea for 2 reasons :
-- it decouples the setup of scrum with the gathering of the initial state, gathering that could happen in several ways (hardcoded, read from some global JSON/Transit data pasted in HTML from the server, a user event, etc.)
-- it allows setting a global watcher in the atom for ad-hoc stuff outside of the normal scrum cycle for maximum flexibility.
+Usually controllers are initialized with their initial state by dispatching `:init` action.
 
-### Dispatch event with the Dispatcher
+*NOTE*: the `:init` event pattern isn't enforced at all by _Scrum_, but we consider it is a good idea for 2 reasons:
+- it separates setup of _Scrum_ from initilization phase, because initilization could happen in several ways (hardcoded, read from some global JSON/Transit data rendered into HTML from the server, a user event, etc.)
+- it allows setting a global watcher in the atom for ad-hoc stuff outside of the normal _Scrum_ cycle for maximum flexibility
+
+### Dispatch event with Dispatcher
 
 Dispatcher communicates intention to perform an action, whether it is updating the state or performing a network request. By default an action is executed asynchronously, use `dispatch-sync!` when synchronous action is required:
 
@@ -159,7 +162,7 @@ Controller is a multimethod which executes actions against application state. A 
   (update db :counter dec))
 ```
 
-It's important to understand that the value returned by a controller won't affect the whole state, but only the part corresponding to its associated key in the `:controllers` map of the reconciler.
+It's important to understand that `db` value that is passed in and returned by a controller won't affect the whole state, but only the part corresponding to its associated key in the `:controllers` map of the reconciler.
 
 ### Query state reactively with Subscriptions
 
@@ -205,8 +208,8 @@ Actual subscription happens in Rum component via `rum/reactive` mixin and `rum/r
 
 ## Best practices
 
-- Pass the reconciler explicity from parents components to children. Since it is reference type it won't affect shouldComponentUpdate aka rum/static optimization. But if you prefer to do it Redux-way, you can use context in Rum as well https://github.com/tonsky/rum/#interop-with-react
-- Set up the initial state by `broadcast-sync!`ing an `:init` event before first rendering. This way you're free to gather the initial as you need in each controller and can setup a global watcher in the atom passed to `:state` in the reconciler.
+- Pass the reconciler explicity from parent components to children. Since it is reference type it won't affect `rum/static` (`shouldComponentUpdate`) optimization. But if you prefer to do it _Redux-way_, you can use context in _Rum_ as well https://github.com/tonsky/rum/#interop-with-react
+- Set up the initial state by `broadcast-sync!`ing an `:init` event before first render. This enforces controllers to keep state initialization in-place where they are defined.
 
 ## Roadmap
 - <strike>Get rid of global state</strike>

--- a/README.md
+++ b/README.md
@@ -203,6 +203,11 @@ Actual subscription happens in Rum component via `rum/reactive` mixin and `rum/r
      [:div (str "Total: " (rum/react (shopping-cart reconciler)))]])
 ```
 
+## Best practices
+
+- Pass the reconciler explicity from parents components to children. Since it is reference type it won't affect shouldComponentUpdate aka rum/static optimization. But if you prefer to do it Redux-way, you can use context in Rum as well https://github.com/tonsky/rum/#interop-with-react
+- Set up the initial state by `broadcast-sync!`ing an `:init` event before first rendering. This way you're free to gather the initial as you need in each controller and can setup a global watcher in the atom passed to `:state` in the reconciler.
+
 ## Roadmap
 - <strike>Get rid of global state</strike>
 - Make scrum isomorphic (in progress, see [this issue](#3))

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Add to project.clj: `[org.roman01la/scrum "1.0.0-SNAPSHOT"]`
 
 ;; create Reconciler instance
 (defonce reconciler
-  (scrum/reconciler {:state (atom {})
+  (scrum/reconciler {:state (atom nil)
                      :controllers {:counter control}}))
 
 ;; initialize controllers
@@ -130,7 +130,7 @@ Dispatcher communicates intention to perform an action, whether it is state upda
 
 ### Controllers
 
-Controller is a multimethod which executes actions against application state. A controller usually have at least an initial state and `:init` method.
+Controller is a multimethod which executes actions against application state (the value inside the atom created with the reconciler). A controller usually have at least an initial state and `:init` method.
 
 ```clojure
 (def initial-state 0)


### PR DESCRIPTION
Since the `Usage` example simply a number as the state, the current use of a map made it hard for me to grasp when this map was reused since the rest of the example manipulates the number directly. I propose using nil and a small clarification of the `Controller` section.